### PR TITLE
type checking for fields

### DIFF
--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -136,16 +136,23 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 			loadedWIT.Description = wit.Description
 			loadedWIT.Icon = wit.Icon
 
-			//-----------------------------------------------------------------
-			// Double check all existing fields are still present in new fields
-			//-----------------------------------------------------------------
-			toBeFoundFields := map[string]struct{}{}
-			for k := range loadedWIT.Fields {
-				toBeFoundFields[k] = struct{}{}
+			//--------------------------------------------------------------------------------
+			// Double check all existing fields are still present in new fields with same type
+			//--------------------------------------------------------------------------------
+			// verify that FieldTypes are same as loadedWIT
+			toBeFoundFields := map[string]workitem.FieldType{}
+			for k, fd := range loadedWIT.Fields {
+				toBeFoundFields[k] = fd.Type
 			}
 			// Remove fields directly defined in WIT
-			for k := range wit.Fields {
-				delete(toBeFoundFields, k)
+			for fieldName, fd := range wit.Fields {
+				// verify FieldType with original value
+				if originalType, ok := toBeFoundFields[fieldName]; ok == true {
+					if fd.Type.Equal(originalType) == false {
+						return errs.Errorf("Type of the field %s changed from %s to %s", fieldName, originalType, fd.Type)
+					}
+				}
+				delete(toBeFoundFields, fieldName)
 			}
 			// Remove fields defined by extended type
 			var extendedType *workitem.WorkItemType

--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -147,7 +147,7 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 			// Remove fields directly defined in WIT
 			for fieldName, fd := range wit.Fields {
 				// verify FieldType with original value
-				if originalType, ok := toBeFoundFields[fieldName]; ok == true {
+				if originalType, ok := toBeFoundFields[fieldName]; ok {
 					if fd.Type.Equal(originalType) == false {
 						return errs.Errorf("Type of the field %s changed from %s to %s", fieldName, originalType, fd.Type)
 					}

--- a/spacetemplate/importer/repository.go
+++ b/spacetemplate/importer/repository.go
@@ -149,7 +149,7 @@ func (r *GormRepository) createOrUpdateWITs(ctx context.Context, s *ImportHelper
 				// verify FieldType with original value
 				if originalType, ok := toBeFoundFields[fieldName]; ok {
 					if fd.Type.Equal(originalType) == false {
-						return errs.Errorf("Type of the field %s changed from %s to %s", fieldName, originalType, fd.Type)
+						return errs.Errorf("type of the field %s changed from %s to %s", fieldName, originalType, fd.Type)
 					}
 				}
 				delete(toBeFoundFields, fieldName)

--- a/spacetemplate/importer/repository_blackbox_test.go
+++ b/spacetemplate/importer/repository_blackbox_test.go
@@ -172,6 +172,31 @@ func (s *repoSuite) TestImport() {
 		})
 	})
 	s.T().Run("invalid", func(t *testing.T) {
+		t.Run("change in field type", func(t *testing.T) {
+			// Create fresh template
+			spaceTemplateID := uuid.NewV4()
+			witID := uuid.NewV4()
+			wiltID := uuid.NewV4()
+			witgID := uuid.NewV4()
+			oldTempl := getValidTestTemplateParsed(t, spaceTemplateID, witID, wiltID, witgID)
+			oldTempl.Template.Name = "old name for space template " + spaceTemplateID.String()
+			_, err := s.importerRepo.Import(s.Ctx, oldTempl)
+			require.NoError(t, err)
+			// Import it once more but this time with changes
+			templ := getValidTestTemplateParsed(t, spaceTemplateID, witID, wiltID, witgID)
+			templ.WITs[0].Fields["title"] = workitem.FieldDefinition{
+				Label:       "Title",
+				Description: "The title of the bug",
+				Required:    true,
+				Type: workitem.SimpleType{
+					Kind: workitem.KindInteger,
+				},
+			}
+			// when
+			_, err = s.importerRepo.Import(s.Ctx, templ)
+			// then
+			require.Error(t, err)
+		})
 		t.Run("WIT already exists", func(t *testing.T) {
 			// given old space template with new name, new ID, and new WILT ID
 			newWILTID := uuid.NewV4()


### PR DESCRIPTION
Verify that old and new field types are the same for existing work item types.

```
time="2018-03-14 10:08:25" level=panic msg="failed to populate common types" err="failed to import space #0 template with name \"Openshift.io Base Space Template\" ID 1f48b7bf-bc51-4823-8101-9f10039035ba:
failed to create or update work item types: type of the field system.order changed from {float} to {string}" pid=15803 req_id=ZnN9Rv3d 
10:8:25 app         | panic: (*logrus.Entry) (0x1a94240,0xc420442140)
``` 

Type equality totally depends upon the `Equal` method implemented in `FieldType` interface by respective `FieldDefinition`.