### PR TITLE
Tests for WILTs and removed delete method

### DIFF
--- a/controller/codebase_blackbox_test.go
+++ b/controller/codebase_blackbox_test.go
@@ -110,8 +110,6 @@ func MockShowTenant() func(context.Context) (*tenant.TenantSingle, error) {
 }
 
 func (s *CodebaseControllerTestSuite) TestShowCodebase() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("success without stackId", func(t *testing.T) {
 		// given
@@ -121,7 +119,7 @@ func (s *CodebaseControllerTestSuite) TestShowCodebase() {
 		_, result := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
 		// then
 		require.NotNil(t, result)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_without_stackId.golden.json"), result)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_without_stackId.golden.json"), result)
 	})
 
 	s.T().Run("success with stackId", func(t *testing.T) {
@@ -135,13 +133,11 @@ func (s *CodebaseControllerTestSuite) TestShowCodebase() {
 		_, result := test.ShowCodebaseOK(t, svc.Context, svc, ctrl, fxt.Codebases[0].ID)
 		// then
 		require.NotNil(t, result)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_with_stackId.golden.json"), result)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_with_stackId.golden.json"), result)
 	})
 }
 
 func (s *CodebaseControllerTestSuite) TestDeleteCodebase() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("OK", func(t *testing.T) {
 		// given

--- a/controller/filters_blackbox_test.go
+++ b/controller/filters_blackbox_test.go
@@ -30,8 +30,6 @@ func TestRunFiltersREST(t *testing.T) {
 }
 
 func (rest *TestFiltersREST) TestListFiltersOK() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	// given
 	svc := goa.New("filterService")
@@ -39,6 +37,6 @@ func (rest *TestFiltersREST) TestListFiltersOK() {
 	// when
 	res, filters := test.ListFilterOK(rest.T(), svc.Context, svc, ctrl)
 	// then
-	compareWithGolden(rest.T(), filepath.Join("test-files", "filter", "list", "list_available_filters.golden.json"), filters)
+	compareWithGoldenAgnostic(rest.T(), filepath.Join("test-files", "filter", "list", "list_available_filters.golden.json"), filters)
 	assertResponseHeaders(rest.T(), res)
 }

--- a/controller/iteration_blackbox_test.go
+++ b/controller/iteration_blackbox_test.go
@@ -93,8 +93,6 @@ func (s *DummySpaceAuthzService) Configuration() authz.AuthzConfiguration {
 }
 
 func (rest *TestIterationREST) TestCreateChildIteration() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("Ok", func(t *testing.T) {
 		t.Run("as space owner", func(t *testing.T) {
@@ -115,9 +113,9 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			resp, created := test.CreateChildIterationCreated(t, svc.Context, svc, ctrl, childItr.ID.String(), ci)
 			// then
 			require.NotNil(t, created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.res.iteration.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.req.payload.golden.json"), ci)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.res.iteration.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child.req.payload.golden.json"), ci)
 		})
 		t.Run("as collaborator", func(t *testing.T) {
 			fxt := tf.NewTestFixture(t, rest.DB,
@@ -154,9 +152,9 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			resp, created := test.CreateChildIterationCreated(t, svc.Context, svc, ctrl, childItr.ID.String(), ci)
 			// then
 			require.NotNil(t, created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.res.iteration.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_ID_paylod.req.payload.golden.json"), ci)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.res.iteration.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_with_ID_paylod.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create_child_ID_paylod.req.payload.golden.json"), ci)
 			require.Equal(t, *ci.Data.ID, *created.Data.ID)
 		})
 	})
@@ -172,8 +170,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			// overwrite service with Dummy Auth to treat user as non-collaborator
 			svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", *notSpaceOwner, &DummySpaceAuthzService{rest})
 			_, jerrs := test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.req.payload.golden.json"), ci)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.req.payload.golden.json"), ci)
 		})
 		t.Run("for non-collaborator", func(t *testing.T) {
 			fxt := tf.NewTestFixture(t, rest.DB,
@@ -185,7 +183,7 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 			// overwrite service with Dummy Auth to treat user as non-collaborator
 			svc := testsupport.ServiceAsSpaceUser("Collaborators-Service", *nonCollaborator, &DummySpaceAuthzService{rest})
 			_, jerrs := test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized_other_user.errors.golden.json"), jerrs)
 		})
 	})
 
@@ -201,8 +199,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		svc, ctrl := rest.SecuredControllerWithIdentity(fxt.Identities[0])
 		_, jerrs := test.CreateChildIterationConflict(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "conflict_for_same_name.req.payload.golden.json"), ci)
 	})
 
 	rest.T().Run("fail - create child iteration missing name", func(t *testing.T) {
@@ -212,8 +210,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		svc, ctrl := rest.SecuredControllerWithIdentity(fxt.Identities[0])
 		_, jerrs := test.CreateChildIterationBadRequest(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_missing_name.req.payload.golden.json"), ci)
 	})
 
 	rest.T().Run("fail - create child missing parent", func(t *testing.T) {
@@ -223,8 +221,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		_, jerrs := test.CreateChildIterationNotFound(t, svc.Context, svc, ctrl, uuid.NewV4().String(), ci)
 		jerrs.Errors[0].ID = ptr.String("IGNORE_ME")
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "bad_request_unknown_parent.req.payload.golden.json"), ci)
 	})
 
 	rest.T().Run("unauthorized - create child iteration with unauthorized user", func(t *testing.T) {
@@ -233,8 +231,8 @@ func (rest *TestIterationREST) TestCreateChildIteration() {
 		svc, ctrl := rest.UnSecuredController()
 		_, jerrs := test.CreateChildIterationUnauthorized(t, svc.Context, svc, ctrl, fxt.Iterations[0].ID.String(), ci)
 		jerrs.Errors[0].ID = ptr.String("IGNORE_ME")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.res.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.req.payload.golden.json"), ci)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.res.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "unauthorized.req.payload.golden.json"), ci)
 	})
 }
 
@@ -267,8 +265,7 @@ func (rest *TestIterationREST) TestFailValidationIterationNameStartWith() {
 }
 
 func (rest *TestIterationREST) TestShowIterationOK() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
+
 	// given
 	fxt := createSpaceAndRootAreaAndIterations(rest.T(), rest.DB)
 	itr := *fxt.Iterations[1]
@@ -280,7 +277,7 @@ func (rest *TestIterationREST) TestShowIterationOK() {
 	require.NotNil(rest.T(), created.Data.Relationships.Workitems.Meta)
 	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta[KeyTotalWorkItems])
 	assert.Equal(rest.T(), 0, created.Data.Relationships.Workitems.Meta[KeyClosedWorkItems])
-	compareWithGoldenUUIDAgnostic(rest.T(), filepath.Join(rest.testDir, "show", "ok.res.iteration.golden.json"), created)
+	compareWithGoldenAgnostic(rest.T(), filepath.Join(rest.testDir, "show", "ok.res.iteration.golden.json"), created)
 }
 
 func (rest *TestIterationREST) TestShowIterationOKUsingExpiredIfModifiedSinceHeader() {
@@ -1147,8 +1144,7 @@ func (rest *TestIterationREST) TestIterationDelete() {
 }
 
 func (rest *TestIterationREST) TestUpdateIteration() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
+
 	rest.T().Run("update success - iteration parent", func(t *testing.T) {
 		// build following structure
 		// 	root 0
@@ -1198,8 +1194,8 @@ func (rest *TestIterationREST) TestUpdateIteration() {
 		// when
 		resp, updatedItr := test.UpdateIterationOK(t, svc.Context, svc, ctrl, itr3.ID.String(), &payload)
 		require.NotNil(t, updatedItr)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.res.iteration.golden.json"), updatedItr)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.headers.golden.json"), resp.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.res.iteration.golden.json"), updatedItr)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok_change_parent.headers.golden.json"), resp.Header())
 		// then
 		require.NotNil(t, updatedItr.Data.Relationships.Parent)
 		assert.Equal(t, newParentIDStr, *updatedItr.Data.Relationships.Parent.Data.ID)

--- a/controller/label_blackbox_test.go
+++ b/controller/label_blackbox_test.go
@@ -94,8 +94,6 @@ func (rest *TestLabelREST) TestCreateLabelWithWhiteSpace() {
 }
 
 func (rest *TestLabelREST) TestUpdate() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	testFxt := tf.NewTestFixture(rest.T(), rest.DB, tf.Labels(1))
 	svc := testsupport.ServiceAsUser("Label-Service", *testFxt.Identities[0])
@@ -121,8 +119,8 @@ func (rest *TestLabelREST) TestUpdate() {
 		}
 		resp, updated := test.UpdateLabelOK(t, svc.Context, svc, ctrl, testFxt.Spaces[0].ID, testFxt.Labels[0].ID, &payload)
 		assert.Equal(t, newName, *updated.Data.Attributes.Name)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok.label.golden.json"), updated)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "ok.headers.golden.json"), resp)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok.label.golden.json"), updated)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "ok.headers.golden.json"), resp)
 
 		_, labels2 := test.ShowLabelOK(t, svc.Context, svc, ctrl, testFxt.Spaces[0].ID, testFxt.Labels[0].ID, nil, nil)
 		assertLabelLinking(t, labels2.Data)
@@ -148,7 +146,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "version conflict")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "conflict.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "conflict.errors.golden.json"), jerrs)
 	})
 
 	rest.T().Run("update label with bad parameter", func(t *testing.T) {
@@ -165,7 +163,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "Bad value for parameter 'data.attributes.version'")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_version.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_version.errors.golden.json"), jerrs)
 	})
 
 	rest.T().Run("update label with bad parameter - name", func(t *testing.T) {
@@ -188,7 +186,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "Bad value for parameter 'label name cannot be empty string'")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_name.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "badparam_name.errors.golden.json"), jerrs)
 	})
 
 	rest.T().Run("update label with unauthorized", func(t *testing.T) {
@@ -210,7 +208,7 @@ func (rest *TestLabelREST) TestUpdate() {
 		require.Contains(t, jerrs.Errors[0].Detail, "Missing token manager")
 		ignoreString := "IGNORE_ME"
 		jerrs.Errors[0].ID = &ignoreString
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "update", "unauthorized.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "update", "unauthorized.errors.golden.json"), jerrs)
 	})
 	rest.T().Run("update label not found", func(t *testing.T) {
 		newName := "Label New 1002"

--- a/controller/planner_backlog.go
+++ b/controller/planner_backlog.go
@@ -95,7 +95,7 @@ func generateBacklogExpression(ctx context.Context, db application.DB, spaceID u
 
 		// Get the list of work item types that derive of PlannerItem in the space
 		var expWits criteria.Expression
-		wits, err := appl.WorkItemTypes().ListPlannerItemTypes(ctx, space.SpaceTemplateID) // TODO(kwk): FIX ME BADLY! DON'T CALL WITH SPACEID
+		wits, err := appl.WorkItemTypes().ListPlannerItemTypes(ctx, space.SpaceTemplateID)
 		if err != nil {
 			return errs.Wrap(err, "unable to fetch work item types that derive from planner item")
 		}

--- a/controller/query_blackbox_test.go
+++ b/controller/query_blackbox_test.go
@@ -77,8 +77,6 @@ func getQueryCreatePayload(title string, qs *string) *app.CreateQueryPayload {
 }
 
 func (rest *TestQueryREST) TestCreate() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
@@ -91,9 +89,9 @@ func (rest *TestQueryREST) TestCreate() {
 			// then
 			require.NotNil(t, created)
 			require.Equal(t, fxt.Identities[0].ID.String(), *created.Data.Relationships.Creator.Data.ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
 		})
 		t.Run("same title with different spaceID", func(t *testing.T) {
 			fxt := tf.NewTestFixture(t, rest.DB,
@@ -106,9 +104,9 @@ func (rest *TestQueryREST) TestCreate() {
 			// then
 			require.NotNil(t, created)
 			require.Equal(t, fxt.Identities[0].ID.String(), *created.Data.Relationships.Creator.Data.ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
 		})
 		t.Run("same object after delete", func(t *testing.T) {
 			queryTitle := "query 1"
@@ -128,9 +126,9 @@ func (rest *TestQueryREST) TestCreate() {
 			// then
 			require.NotNil(t, created)
 			require.Equal(t, fxt.Identities[0].ID.String(), *created.Data.Relationships.Creator.Data.ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.res.query.golden.json"), created)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "create", "ok_create.req.payload.golden.json"), cq)
 		})
 	})
 
@@ -173,8 +171,6 @@ func (rest *TestQueryREST) TestCreate() {
 }
 
 func (rest *TestQueryREST) TestList() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {
@@ -239,8 +235,6 @@ func (rest *TestQueryREST) TestList() {
 }
 
 func (rest *TestQueryREST) TestShow() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok with identity", func(t *testing.T) {
@@ -253,8 +247,8 @@ func (rest *TestQueryREST) TestShow() {
 			resp, queryObj := test.ShowQueryOK(t, svc.Context, svc, ctrl, fxt.Spaces[0].ID, q.ID, nil, nil)
 			// then
 			require.NotNil(t, queryObj)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.res.query.golden.json"), queryObj)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.headers.golden.json"), resp.Header())
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.res.query.golden.json"), queryObj)
+			compareWithGoldenAgnostic(t, filepath.Join(rest.testDir, "show", "ok_show.headers.golden.json"), resp.Header())
 		})
 	})
 
@@ -301,8 +295,6 @@ func (rest *TestQueryREST) TestShow() {
 }
 
 func (rest *TestQueryREST) TestDelete() {
-	resetFn := rest.DisableGormCallbacks()
-	defer resetFn()
 
 	rest.T().Run("success", func(t *testing.T) {
 		t.Run("ok with identity", func(t *testing.T) {

--- a/controller/search_blackbox_test.go
+++ b/controller/search_blackbox_test.go
@@ -1072,8 +1072,6 @@ func (s *searchControllerTestSuite) TestSearchByJoinedData() {
 
 // TestIncludedParents verifies the Included list of parents
 func (s *searchControllerTestSuite) TestIncludedParents() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	fxt := tf.NewTestFixture(s.T(), s.DB,
 		tf.WorkItems(5, tf.SetWorkItemTitles("A", "B", "C", "D", "E")),
@@ -1140,7 +1138,7 @@ func (s *searchControllerTestSuite) TestIncludedParents() {
 				// then
 				require.NotEmpty(t, result.Data)
 				assert.Len(t, result.Data, len(searchForTitles))
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", strings.Replace("in topology A-B-C and A-D search for", " ", "_", -1), strings.Replace(testName+".res.golden.json", " ", "_", -1)), result)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", strings.Replace("in topology A-B-C and A-D search for", " ", "_", -1), strings.Replace(testName+".res.golden.json", " ", "_", -1)), result)
 
 				// test what's included in the "data" portion of the response
 				for _, wi := range result.Data {
@@ -1233,8 +1231,6 @@ func (s *searchControllerTestSuite) TestIncludedParents() {
 }
 
 func (s *searchControllerTestSuite) TestIncludedChildren() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	// Suppose we have this topology:
 	//
@@ -1324,7 +1320,7 @@ func (s *searchControllerTestSuite) TestIncludedChildren() {
 			require.Empty(t, toBeFound, "failed to find these work items: %s", toBeFound.ToString(", ", func(ID uuid.UUID) string {
 				return fxt.WorkItemByID(ID).Fields[workitem.SystemTitle].(string)
 			}))
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "include_children.res.payload.golden.json"), result)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "include_children.res.payload.golden.json"), result)
 		})
 
 		t.Run("B,C with tree-view = false", func(t *testing.T) {
@@ -1348,14 +1344,12 @@ func (s *searchControllerTestSuite) TestIncludedChildren() {
 				return fxt.WorkItemByID(ID).Fields[workitem.SystemTitle].(string)
 			}))
 			// check "included" section
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "do_not_include_children.res.payload.golden.json"), result)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", testFolder, "do_not_include_children.res.payload.golden.json"), result)
 		})
 	})
 }
 
 func (s *searchControllerTestSuite) TestUpdateWorkItem() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("assignees", func(t *testing.T) {
 		// given
@@ -1386,10 +1380,10 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 				wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
 				payload2 := app.UpdateWorkitemPayload{Data: wi}
 				_, updated := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_update_work_item.golden.json"), updated)
 
 				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_show_after_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_assignee_null_show_after_update_work_item.golden.json"), updated)
 				assert.Nil(s.T(), result.Data[0].Attributes[workitem.SystemAssignees])
 
 			})
@@ -1424,10 +1418,10 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 				wi.Attributes[workitem.SystemTitle] = "Updated Test WI"
 				payload2 := app.UpdateWorkitemPayload{Data: wi}
 				_, updated := test.UpdateWorkitemOK(t, s.svc.Context, s.svc, workitemCtrl, *wi.ID, &payload2)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_update_work_item.golden.json"), updated)
 
 				_, result = test.ShowSearchOK(t, nil, nil, s.controller, &filter, nil, nil, nil, nil, nil)
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_show_after_update_work_item.golden.json"), updated)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "filter_label_null_show_after_update_work_item.golden.json"), updated)
 				assert.Nil(s.T(), result.Data[0].Attributes[workitem.SystemLabels])
 			})
 		})
@@ -1435,8 +1429,6 @@ func (s *searchControllerTestSuite) TestUpdateWorkItem() {
 }
 
 func (s *searchControllerTestSuite) TestSearchCodebases() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("Single match", func(t *testing.T) {
 		// given
@@ -1452,7 +1444,7 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 		require.NotNil(t, codebaseList)
 		require.NotNil(t, codebaseList.Data)
 		require.Len(t, codebaseList.Data, 1)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_single_match.json"), codebaseList)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_single_match.json"), codebaseList)
 	})
 
 	s.T().Run("Multi-match", func(t *testing.T) {
@@ -1478,7 +1470,7 @@ func (s *searchControllerTestSuite) TestSearchCodebases() {
 		sort.Sort(SortableCodebasesByID(codebaseList.Data))
 		// for included spaces, we must sort the spaces by their ID
 		sort.Sort(SortableIncludedSpacesByID(codebaseList.Included))
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_multi_match.json"), codebaseList)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "search_codebase_per_url_multi_match.json"), codebaseList)
 	})
 }
 

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -120,9 +120,6 @@ func (s *SpaceControllerTestSuite) TestValidateSpaceName() {
 }
 
 func (s *SpaceControllerTestSuite) TestCreateSpace() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("Fail - unsecure", func(t *testing.T) {
 		// given
 		p := newCreateSpacePayload(nil, nil)
@@ -137,7 +134,7 @@ func (s *SpaceControllerTestSuite) TestCreateSpace() {
 		p := newCreateSpacePayload(&name, nil)
 		svc, ctrl := s.SecuredController(testsupport.TestIdentity)
 		// when
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.payload.req.golden.json"), p)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.payload.req.golden.json"), p)
 		res, created := test.CreateSpaceCreated(t, svc.Context, svc, ctrl, p)
 		// then
 		require.NotNil(t, created.Data)
@@ -148,8 +145,8 @@ func (s *SpaceControllerTestSuite) TestCreateSpace() {
 		assert.Equal(t, name, *created.Data.Attributes.Name)
 		require.NotNil(t, created.Data.Links)
 		assert.NotNil(t, created.Data.Links.Self)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.payload.res.golden.json"), created)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.headers.res.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.payload.res.golden.json"), created)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.headers.res.golden.json"), res.Header())
 	})
 
 	s.T().Run("ok with default area", func(t *testing.T) {
@@ -442,7 +439,7 @@ func (s *SpaceControllerTestSuite) TestShowSpace() {
 		eTag, lastModified, _ := assertResponseHeaders(t, res)
 		assert.Equal(t, app.ToHTTPTime(getSpaceUpdatedAt(*created)), lastModified)
 		assert.Equal(t, generateSpaceTag(*created), eTag)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.payload.res.golden.json"), fetched)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.payload.res.golden.json"), fetched)
 	})
 
 	s.T().Run("conditional request", func(t *testing.T) {

--- a/controller/space_blackbox_test.go
+++ b/controller/space_blackbox_test.go
@@ -424,8 +424,6 @@ func (s *SpaceControllerTestSuite) TestUpdateSpace() {
 func (s *SpaceControllerTestSuite) TestShowSpace() {
 
 	// needed to valid comparison with golden files
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("ok", func(t *testing.T) {
 		// given
@@ -440,7 +438,7 @@ func (s *SpaceControllerTestSuite) TestShowSpace() {
 		eTag, lastModified, _ := assertResponseHeaders(t, res)
 		assert.Equal(t, app.ToHTTPTime(getSpaceUpdatedAt(*created)), lastModified)
 		assert.Equal(t, generateSpaceTag(*created), eTag)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show_space_ok.golden.json"), fetched)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show_space_ok.golden.json"), fetched)
 	})
 
 	s.T().Run("conditional request", func(t *testing.T) {

--- a/controller/space_template.go
+++ b/controller/space_template.go
@@ -1,37 +1,3 @@
-// package controller
-
-// import (
-// 	"github.com/fabric8-services/fabric8-wit/app"
-// 	"github.com/fabric8-services/fabric8-wit/application"
-// 	"github.com/fabric8-services/fabric8-wit/jsonapi"
-// 	"github.com/goadesign/goa"
-// )
-
-// // SpaceTemplateController implements the space_template resource.
-// type SpaceTemplateController struct {
-// 	*goa.Controller
-// 	db application.DB
-// }
-
-// // NewSpaceTemplateController creates a space_template controller.
-// func NewSpaceTemplateController(service *goa.Service, db application.DB) *SpaceTemplateController {
-// 	return &SpaceTemplateController{Controller: service.NewController("SpaceTemplateController"), db: db}
-// }
-
-// // Show runs the show action.
-// func (c *SpaceTemplateController) Show(ctx *app.ShowSpaceTemplateContext) error {
-// 	// till we have space templates in place, let this controller redirect
-// 	// user to the typegroups endpoint that returns list of type-groups.
-// 	err := application.Transactional(c.db, func(appl application.Application) error {
-// 		return appl.Spaces().CheckExists(ctx, ctx.SpaceTemplateID.String())
-// 	})
-// 	if err != nil {
-// 		return jsonapi.JSONErrorResponse(ctx, err)
-// 	}
-// 	typeGroupURL := app.SpaceTemplateHref(ctx.SpaceTemplateID) + "/workitemtypegroups/"
-// 	ctx.ResponseData.Header().Set("Location", typeGroupURL)
-// 	return ctx.TemporaryRedirect()
-// }
 package controller
 
 import (

--- a/controller/space_template_blackbox_test.go
+++ b/controller/space_template_blackbox_test.go
@@ -54,9 +54,6 @@ func (s *testSpaceTemplateSuite) SecuredController() (*goa.Service, *SpaceTempla
 }
 
 func (s *testSpaceTemplateSuite) TestSpaceTemplate_Show() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("non-existing template", func(t *testing.T) {
 		// given
 		svc, ctrl := s.SecuredController()
@@ -77,8 +74,8 @@ func (s *testSpaceTemplateSuite) TestSpaceTemplate_Show() {
 		res, actual := test.ShowSpaceTemplateOK(t, svc.Context, svc, ctrl, fxt.SpaceTemplates[0].ID, nil, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "m2MLfQTqVSfIsr8Dt9pjMQ==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.payload.golden.json"), actual)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.payload.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 		require.NotNil(t, actual)
 		assertResponseHeaders(t, res)
 		actualModel := convertSpaceTemplateSingleToModel(t, *actual)
@@ -142,8 +139,6 @@ func (s *testSpaceTemplateSuite) TestSpaceTemplate_List() {
 	}
 
 	s.T().Run("ok", func(t *testing.T) {
-		resetFn := s.DisableGormCallbacks()
-		defer resetFn()
 		// given
 		fxt := tf.NewTestFixture(s.T(), s.DB, tf.SpaceTemplates(3))
 		// when

--- a/controller/test-files/iteration/create/bad_request_missing_name.req.payload.golden.json
+++ b/controller/test-files/iteration/create/bad_request_missing_name.req.payload.golden.json
@@ -2,8 +2,8 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
-      "startAt": "2006-01-02T15:04:00Z"
+      "endAt": "0001-01-01T00:00:00Z",
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/create/bad_request_unknown_parent.req.payload.golden.json
+++ b/controller/test-files/iteration/create/bad_request_unknown_parent.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2006-01-02T15:04:00Z"
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/create/conflict_for_same_name.req.payload.golden.json
+++ b/controller/test-files/iteration/create/conflict_for_same_name.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "iteration 00000000-0000-0000-0000-000000000001",
-      "startAt": "2006-01-02T15:04:00Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "user_active": false
     },
     "type": "iterations"

--- a/controller/test-files/iteration/create/ok_create_child.req.payload.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "user_active": false
     },
     "type": "iterations"

--- a/controller/test-files/iteration/create/ok_create_child.res.iteration.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child.res.iteration.golden.json
@@ -4,11 +4,11 @@
       "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
       "parent_path": "/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/root/child",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false

--- a/controller/test-files/iteration/create/ok_create_child_ID_paylod.req.payload.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_ID_paylod.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "user_active": false
     },
     "id": "00000000-0000-0000-0000-000000000001",

--- a/controller/test-files/iteration/create/ok_create_child_with_ID_paylod.res.iteration.golden.json
+++ b/controller/test-files/iteration/create/ok_create_child_with_ID_paylod.res.iteration.golden.json
@@ -4,11 +4,11 @@
       "active_status": false,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2016-11-25T15:08:41Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
       "parent_path": "/00000000-0000-0000-0000-000000000001/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/root/child",
-      "startAt": "2016-11-04T15:08:41Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false

--- a/controller/test-files/iteration/create/unauthorized.req.payload.golden.json
+++ b/controller/test-files/iteration/create/unauthorized.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2006-01-02T15:04:00Z"
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/create/unauthorized_other_user.req.payload.golden.json
+++ b/controller/test-files/iteration/create/unauthorized_other_user.req.payload.golden.json
@@ -2,9 +2,9 @@
   "data": {
     "attributes": {
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "Sprint #21",
-      "startAt": "2006-01-02T15:04:00Z"
+      "startAt": "0001-01-01T00:00:00Z"
     },
     "type": "iterations"
   }

--- a/controller/test-files/iteration/show/ok.res.iteration.golden.json
+++ b/controller/test-files/iteration/show/ok.res.iteration.golden.json
@@ -4,11 +4,11 @@
       "active_status": true,
       "created-at": "0001-01-01T00:00:00Z",
       "description": "Some description",
-      "endAt": "2105-12-09T15:04:00Z",
+      "endAt": "0001-01-01T00:00:00Z",
       "name": "iteration 00000000-0000-0000-0000-000000000001",
       "parent_path": "/00000000-0000-0000-0000-000000000002",
       "resolved_parent_path": "/space 00000000-0000-0000-0000-000000000003",
-      "startAt": "2006-01-02T15:04:00Z",
+      "startAt": "0001-01-01T00:00:00Z",
       "state": "new",
       "updated-at": "0001-01-01T00:00:00Z",
       "user_active": false

--- a/controller/test-files/work_item_link_types/list/ok.payload.golden.json
+++ b/controller/test-files/work_item_link_types/list/ok.payload.golden.json
@@ -3,48 +3,148 @@
     {
       "attributes": {
         "created-at": "0001-01-01T00:00:00Z",
-        "description": "some description",
-        "forward_name": "forward name (e.g. blocks)",
-        "name": "work item link type 00000000-0000-0000-0000-000000000001",
-        "reverse_name": "reverse name (e.g. blocked by)",
-        "topology": "tree",
+        "description": "One work item item blocks another one",
+        "forward_name": "blocks",
+        "name": "Blocker",
+        "reverse_name": "blocked by",
+        "topology": "network",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "00000000-0000-0000-0000-000000000002",
+      "id": "00000000-0000-0000-0000-000000000001",
       "links": {
-        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000002",
-        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000002"
+        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000001",
+        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000001"
       },
       "relationships": {
         "link_category": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000002",
             "type": "workitemlinkcategories"
           },
           "links": {
-            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000003",
-            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000003"
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000002"
           }
         },
         "space": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
+            "id": "00000000-0000-0000-0000-000000000003",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
           }
         },
         "space_template": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000005",
+            "id": "00000000-0000-0000-0000-000000000004",
             "type": "spacetemplates"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000005",
-            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000005"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004"
+          }
+        }
+      },
+      "type": "workitemlinktypes"
+    },
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "One work item relates to another one.",
+        "forward_name": "relates to",
+        "name": "Related",
+        "reverse_name": "is related to",
+        "topology": "network",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000005",
+      "links": {
+        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000005",
+        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000005"
+      },
+      "relationships": {
+        "link_category": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemlinkcategories"
+          },
+          "links": {
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004"
+          }
+        }
+      },
+      "type": "workitemlinktypes"
+    },
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "One work item is the parent of another one.",
+        "forward_name": "parent of",
+        "name": "Parenting",
+        "reverse_name": "child of",
+        "topology": "tree",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000006",
+      "links": {
+        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000006",
+        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000006"
+      },
+      "relationships": {
+        "link_category": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "type": "workitemlinkcategories"
+          },
+          "links": {
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000002",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000002"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000004",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000004"
           }
         }
       },
@@ -55,46 +155,96 @@
         "created-at": "0001-01-01T00:00:00Z",
         "description": "some description",
         "forward_name": "forward name (e.g. blocks)",
-        "name": "work item link type 00000000-0000-0000-0000-000000000006",
+        "name": "work item link type 00000000-0000-0000-0000-000000000007",
         "reverse_name": "reverse name (e.g. blocked by)",
         "topology": "tree",
         "updated-at": "0001-01-01T00:00:00Z",
         "version": 0
       },
-      "id": "00000000-0000-0000-0000-000000000007",
+      "id": "00000000-0000-0000-0000-000000000008",
       "links": {
-        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000007",
-        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000007"
+        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000008",
+        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000008"
       },
       "relationships": {
         "link_category": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000003",
+            "id": "00000000-0000-0000-0000-000000000009",
             "type": "workitemlinkcategories"
           },
           "links": {
-            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000003",
-            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000003"
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000009",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000009"
           }
         },
         "space": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000004",
+            "id": "00000000-0000-0000-0000-000000000003",
             "type": "spaces"
           },
           "links": {
-            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000004",
-            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000004"
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
           }
         },
         "space_template": {
           "data": {
-            "id": "00000000-0000-0000-0000-000000000005",
+            "id": "00000000-0000-0000-0000-000000000010",
             "type": "spacetemplates"
           },
           "links": {
-            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000005",
-            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000005"
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010"
+          }
+        }
+      },
+      "type": "workitemlinktypes"
+    },
+    {
+      "attributes": {
+        "created-at": "0001-01-01T00:00:00Z",
+        "description": "some description",
+        "forward_name": "forward name (e.g. blocks)",
+        "name": "work item link type 00000000-0000-0000-0000-000000000011",
+        "reverse_name": "reverse name (e.g. blocked by)",
+        "topology": "tree",
+        "updated-at": "0001-01-01T00:00:00Z",
+        "version": 0
+      },
+      "id": "00000000-0000-0000-0000-000000000012",
+      "links": {
+        "related": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000012",
+        "self": "http:///api/workitemlinktypes/00000000-0000-0000-0000-000000000012"
+      },
+      "relationships": {
+        "link_category": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000009",
+            "type": "workitemlinkcategories"
+          },
+          "links": {
+            "related": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000009",
+            "self": "http:///api/workitemlinkcategories/00000000-0000-0000-0000-000000000009"
+          }
+        },
+        "space": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000003",
+            "type": "spaces"
+          },
+          "links": {
+            "related": "http:///api/spaces/00000000-0000-0000-0000-000000000003",
+            "self": "http:///api/spaces/00000000-0000-0000-0000-000000000003"
+          }
+        },
+        "space_template": {
+          "data": {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "type": "spacetemplates"
+          },
+          "links": {
+            "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010",
+            "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000010"
           }
         }
       },
@@ -102,6 +252,6 @@
     }
   ],
   "meta": {
-    "totalCount": 2
+    "totalCount": 5
   }
 }

--- a/controller/test-files/work_item_type/create/animal.headers.golden.json
+++ b/controller/test-files/work_item_type/create/animal.headers.golden.json
@@ -3,6 +3,6 @@
     "application/vnd.api+json"
   ],
   "Location": [
-    "/api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2/workitemtypes/729431f2-bca4-4062-9087-c751807b569f"
+    "/api/spaces/00000000-0000-0000-0000-000000000001/workitemtypes/00000000-0000-0000-0000-000000000002"
   ]
 }

--- a/controller/test-files/work_item_type/create/animal.wit.golden.json
+++ b/controller/test-files/work_item_type/create/animal.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/create/person.golden.json
+++ b/controller/test-files/work_item_type/create/person.golden.json
@@ -18,16 +18,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "22a1e4f1-7e9d-4ce8-ac87-fe7c79356b16",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/create/person.headers.golden.json
+++ b/controller/test-files/work_item_type/create/person.headers.golden.json
@@ -3,6 +3,6 @@
     "application/vnd.api+json"
   ],
   "Location": [
-    "/api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2/workitemtypes/22a1e4f1-7e9d-4ce8-ac87-fe7c79356b16"
+    "/api/spaces/00000000-0000-0000-0000-000000000001/workitemtypes/00000000-0000-0000-0000-000000000002"
   ]
 }

--- a/controller/test-files/work_item_type/show/ok.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok.wit.golden.json
@@ -46,12 +46,12 @@
       },
       "space_template": {
         "data": {
-          "id": "929c963a-174c-4c37-b487-272067e88bd4",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "spacetemplates"
         },
         "links": {
-          "related": "http:///api/spacetemplates/929c963a-174c-4c37-b487-272067e88bd4",
-          "self": "http:///api/spacetemplates/929c963a-174c-4c37-b487-272067e88bd4"
+          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+          "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok_using_expired_etag_header.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_etag_header.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok_using_expired_etag_header.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_etag_header.wit.golden.json
@@ -46,12 +46,12 @@
       },
       "space_template": {
         "data": {
-          "id": "929c963a-174c-4c37-b487-272067e88bd4",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "spacetemplates"
         },
         "links": {
-          "related": "http:///api/spacetemplates/929c963a-174c-4c37-b487-272067e88bd4",
-          "self": "http:///api/spacetemplates/929c963a-174c-4c37-b487-272067e88bd4"
+          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+          "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.wit.golden.json
@@ -32,16 +32,16 @@
       "updated-at": "0001-01-01T00:00:00Z",
       "version": 0
     },
-    "id": "729431f2-bca4-4062-9087-c751807b569f",
+    "id": "00000000-0000-0000-0000-000000000001",
     "relationships": {
       "space": {
         "data": {
-          "id": "2e0698d8-753e-4cef-bb7c-f027634824a2",
+          "id": "00000000-0000-0000-0000-000000000002",
           "type": "spaces"
         },
         "links": {
-          "related": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2",
-          "self": "http:///api/spaces/2e0698d8-753e-4cef-bb7c-f027634824a2"
+          "related": "http:///api/spaces/00000000-0000-0000-0000-000000000002",
+          "self": "http:///api/spaces/00000000-0000-0000-0000-000000000002"
         }
       }
     },

--- a/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.wit.golden.json
+++ b/controller/test-files/work_item_type/show/ok_using_expired_lastmodified_header.wit.golden.json
@@ -46,12 +46,12 @@
       },
       "space_template": {
         "data": {
-          "id": "929c963a-174c-4c37-b487-272067e88bd4",
+          "id": "00000000-0000-0000-0000-000000000003",
           "type": "spacetemplates"
         },
         "links": {
-          "related": "http:///api/spacetemplates/929c963a-174c-4c37-b487-272067e88bd4",
-          "self": "http:///api/spacetemplates/929c963a-174c-4c37-b487-272067e88bd4"
+          "related": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003",
+          "self": "http:///api/spacetemplates/00000000-0000-0000-0000-000000000003"
         }
       }
     },

--- a/controller/work_item_children_blackbox_test.go
+++ b/controller/work_item_children_blackbox_test.go
@@ -120,9 +120,6 @@ func checkChildrenRelationship(t *testing.T, wi *app.WorkItem, expectedHasChildr
 
 func (s *workItemChildSuite) TestChildren() {
 	s.T().Run("ok", func(t *testing.T) {
-		resetFn := s.DisableGormCallbacks()
-		defer resetFn()
-
 		// given
 		fxt := tf.NewTestFixture(s.T(), s.DB,
 			tf.WorkItemLinkTypes(1, func(fxt *tf.TestFixture, idx int) error {
@@ -138,14 +135,14 @@ func (s *workItemChildSuite) TestChildren() {
 				// when
 				_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, fxt.WorkItemByTitle("parent").ID, nil, nil)
 				// then
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.has_children.res.payload.golden.json"), workItem)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.has_children.res.payload.golden.json"), workItem)
 				checkChildrenRelationship(t, workItem.Data, hasChildren)
 			})
 			t.Run("no children", func(t *testing.T) {
 				// when
 				_, workItem := test.ShowWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, fxt.WorkItemByTitle("child1").ID, nil, nil)
 				// then
-				compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.has_no_children.res.payload.golden.json"), workItem)
+				compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.has_no_children.res.payload.golden.json"), workItem)
 				checkChildrenRelationship(t, workItem.Data, hasNoChildren)
 			})
 		})
@@ -153,7 +150,7 @@ func (s *workItemChildSuite) TestChildren() {
 			// when
 			res, workItemList := test.ListChildrenWorkitemOK(t, s.svc.Context, s.svc, s.workItemCtrl, fxt.WorkItemByTitle("parent").ID, nil, nil, nil, nil)
 			// then
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list_children", "ok.res.payload.golden.json"), workItemList)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list_children", "ok.res.payload.golden.json"), workItemList)
 			toBeFound := id.Slice{fxt.WorkItemByTitle("child1").ID, fxt.WorkItemByTitle("child2").ID}.ToMap()
 			for _, wi := range workItemList.Data {
 				_, ok := toBeFound[*wi.ID]

--- a/controller/work_item_link_blackbox_test.go
+++ b/controller/work_item_link_blackbox_test.go
@@ -143,14 +143,13 @@ func (s *workItemLinkSuite) SecuredController(identity account.Identity) (*goa.S
 }
 
 func (s *workItemLinkSuite) TestCreate() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
+
 	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
 		// helper function used in all ok-cases
 		createOK := func(t *testing.T, fxt *tf.TestFixture, svc *goa.Service, ctrl *WorkItemLinkController) {
 			// when
 			createPayload := newCreateWorkItemLinkPayload(fxt.WorkItems[0].ID, fxt.WorkItems[1].ID, fxt.WorkItemLinkTypes[0].ID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.req.payload.golden.json"), createPayload)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.req.payload.golden.json"), createPayload)
 			res, workItemLink := test.CreateWorkItemLinkCreated(t, svc.Context, svc, ctrl, createPayload)
 			// then
 			require.NotNil(t, workItemLink)
@@ -184,9 +183,9 @@ func (s *workItemLinkSuite) TestCreate() {
 			}
 			require.Empty(t, 0, expectedIDs, "these elements where missing from the included objects: %+v", expectedIDs)
 
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.payload.golden.json"), workItemLink)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.payload.golden.json"), workItemLink)
 			res.Header().Set("Etag", "0icd7ov5CqwDXN6Fx9z18g==") // overwrite Etag to always match
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.headers.golden.json"), res)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "ok.res.headers.golden.json"), res)
 		}
 
 		t.Run("as space owner", func(t *testing.T) {
@@ -319,8 +318,6 @@ func (s *workItemLinkSuite) TestDelete() {
 func (s *workItemLinkSuite) TestShow() {
 	s.T().Run(http.StatusText(http.StatusOK), func(t *testing.T) {
 		t.Run("normal", func(t *testing.T) {
-			resetFn := s.DisableGormCallbacks()
-			defer resetFn()
 
 			// given
 			fxt := tf.NewTestFixture(t, s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
@@ -334,9 +331,9 @@ func (s *workItemLinkSuite) TestShow() {
 			require.Equal(t, fxt.WorkItemLinks[0].SourceID, actual.SourceID)
 			require.Equal(t, fxt.WorkItemLinks[0].TargetID, actual.TargetID)
 			require.Equal(t, fxt.WorkItemLinks[0].LinkTypeID, actual.LinkTypeID)
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.payload.golden.json"), l)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.payload.golden.json"), l)
 			res.Header().Set("Etag", "0icd7ov5CqwDXN6Fx9z18g==") // overwrite Etag to always match
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.headers.golden.json"), res)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.res.headers.golden.json"), res)
 		})
 		t.Run("using expired IfModifiedSince header", func(t *testing.T) {
 			// given
@@ -400,14 +397,13 @@ func (s *workItemLinkSuite) TestShow() {
 			_, jerrs := test.ShowWorkItemLinkNotFound(t, svc.Context, svc, ctrl, uuid.NewV4(), nil, nil)
 			ignoreMe := "IGNOREME"
 			jerrs.Errors[0].ID = &ignoreMe
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.res.errors.golden.json"), jerrs)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.res.errors.golden.json"), jerrs)
 		})
 	})
 }
 
 func (s *workItemLinkSuite) TestList() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
+
 	// given
 	fxt := tf.NewTestFixture(s.T(), s.DB, tf.CreateWorkItemEnvironment(), tf.WorkItemLinks(1))
 	svc, _ := s.SecuredController(*fxt.Identities[0])
@@ -425,7 +421,7 @@ func (s *workItemLinkSuite) TestList() {
 				}
 			}
 			// then
-			compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.paylpad.golden.json"), links)
+			compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.paylpad.golden.json"), links)
 		})
 	})
 	s.T().Run(http.StatusText(http.StatusNotFound), func(t *testing.T) {

--- a/controller/work_item_link_type_blackbox_test.go
+++ b/controller/work_item_link_type_blackbox_test.go
@@ -55,9 +55,6 @@ func safeOverriteHeader(t *testing.T, res http.ResponseWriter, key string, val s
 }
 
 func (s *workItemLinkTypeSuite) TestShow() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	// given
 	fxt := tf.NewTestFixture(s.T(), s.DB, tf.WorkItemLinkTypes(1))
 	wilt := fxt.WorkItemLinkTypes[0]
@@ -67,8 +64,8 @@ func (s *workItemLinkTypeSuite) TestShow() {
 		res, shownWilt := test.ShowWorkItemLinkTypeOK(t, nil, nil, s.linkTypeCtrl, wilt.ID, nil, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.golden.json"), shownWilt)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.golden.json"), shownWilt)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 		// spew.Dump(res.Header())
 		assertResponseHeaders(t, res)
 	})
@@ -79,8 +76,8 @@ func (s *workItemLinkTypeSuite) TestShow() {
 		res, shownWilt := test.ShowWorkItemLinkTypeOK(t, nil, nil, s.linkTypeCtrl, wilt.ID, &ifModifiedSinceHeader, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifmodifiedsince_header.golden.json"), shownWilt)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifmodifiedsince_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifmodifiedsince_header.golden.json"), shownWilt)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifmodifiedsince_header.headers.golden.json"), res.Header())
 		assertResponseHeaders(t, res)
 	})
 
@@ -90,8 +87,8 @@ func (s *workItemLinkTypeSuite) TestShow() {
 		res, shownWilt := test.ShowWorkItemLinkTypeOK(t, nil, nil, s.linkTypeCtrl, wilt.ID, nil, &ifNoneMatch)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifnonematch_header.golden.json"), shownWilt)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifnonematch_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifnonematch_header.golden.json"), shownWilt)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_ifnonematch_header.headers.golden.json"), res.Header())
 		assertResponseHeaders(t, res)
 	})
 
@@ -101,7 +98,7 @@ func (s *workItemLinkTypeSuite) TestShow() {
 		res := test.ShowWorkItemLinkTypeNotModified(t, nil, nil, s.linkTypeCtrl, wilt.ID, &ifModifiedSinceHeader, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_ifmodifiedsince_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_ifmodifiedsince_header.headers.golden.json"), res.Header())
 		assertResponseHeaders(t, res)
 	})
 
@@ -111,14 +108,14 @@ func (s *workItemLinkTypeSuite) TestShow() {
 		res := test.ShowWorkItemLinkTypeNotModified(t, nil, nil, s.linkTypeCtrl, wilt.ID, nil, &ifNoneMatch)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
 		assertResponseHeaders(t, res)
 	})
 
 	s.T().Run("not found", func(t *testing.T) {
 		res, jerrs := test.ShowWorkItemLinkTypeNotFound(t, nil, nil, s.linkTypeCtrl, uuid.FromStringOrNil("303badca-ea6b-440d-a964-1c925a174969"), nil, nil)
 		// then
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.headers.golden.json"), res.Header())
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.golden.json"), jerrs)
 	})
 }

--- a/controller/work_item_link_types_blackbox_test.go
+++ b/controller/work_item_link_types_blackbox_test.go
@@ -45,9 +45,6 @@ func TestNewWorkItemLinkTypesControllerDBNull(t *testing.T) {
 }
 
 func (s *workItemLinkTypesSuite) TestList() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	// given
 	fxt := tf.NewTestFixture(s.T(), s.DB, tf.WorkItemLinkTypes(2))
 	wilt1 := fxt.WorkItemLinkTypes[0]
@@ -71,8 +68,8 @@ func (s *workItemLinkTypesSuite) TestList() {
 		res, linkTypes := test.ListWorkItemLinkTypesOK(t, nil, nil, s.linkTypeCtrl, fxt.SpaceTemplates[0].ID, nil, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "EZUYNwJobqN2yZeWw7GuZw==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.payload.golden.json"), linkTypes)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.payload.golden.json"), linkTypes)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
 		requireWILTsIncluded(t, linkTypes)
 		assertResponseHeaders(t, res)
 	})
@@ -83,7 +80,7 @@ func (s *workItemLinkTypesSuite) TestList() {
 		res, linkTypes := test.ListWorkItemLinkTypesOK(t, nil, nil, s.linkTypeCtrl, fxt.SpaceTemplates[0].ID, &ifModifiedSinceHeader, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "EZUYNwJobqN2yZeWw7GuZw==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok_using_expired_ifmodifiedsince_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok_using_expired_ifmodifiedsince_header.headers.golden.json"), res.Header())
 		requireWILTsIncluded(t, linkTypes)
 		assertResponseHeaders(t, res)
 	})
@@ -94,7 +91,7 @@ func (s *workItemLinkTypesSuite) TestList() {
 		res, linkTypes := test.ListWorkItemLinkTypesOK(t, nil, nil, s.linkTypeCtrl, fxt.SpaceTemplates[0].ID, nil, &ifNoneMatch)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok_using_expired_ifnonematch_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok_using_expired_ifnonematch_header.headers.golden.json"), res.Header())
 		requireWILTsIncluded(t, linkTypes)
 		assertResponseHeaders(t, res)
 	})
@@ -105,7 +102,7 @@ func (s *workItemLinkTypesSuite) TestList() {
 		res := test.ListWorkItemLinkTypesNotModified(t, nil, nil, s.linkTypeCtrl, fxt.SpaceTemplates[0].ID, &ifModifiedSinceHeader, nil)
 		// then
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "not_modified_using_ifmodifiedsince_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "not_modified_using_ifmodifiedsince_header.headers.golden.json"), res.Header())
 		assertResponseHeaders(t, res)
 	})
 
@@ -126,7 +123,7 @@ func (s *workItemLinkTypesSuite) TestList() {
 		ifNoneMatch := app.GenerateEntitiesTag(createdWorkItemLinkTypeModels)
 		res := test.ListWorkItemLinkTypesNotModified(t, nil, nil, s.linkTypeCtrl, fxt.SpaceTemplates[0].ID, nil, &ifNoneMatch)
 		safeOverriteHeader(t, res, app.ETag, "IGos54TQC8+mZ70zZAWQQg==")
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
 		// then
 		assertResponseHeaders(t, res)
 	})

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -41,9 +41,6 @@ func (s *workItemTypeGroupSuite) SetupTest() {
 }
 
 func (s *workItemTypeGroupSuite) TestList() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("ok", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemTypeGroups(3))
@@ -67,9 +64,6 @@ func (s *workItemTypeGroupSuite) TestList() {
 }
 
 func (s *workItemTypeGroupSuite) TestShow() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("ok", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemTypeGroups(1))

--- a/controller/work_item_type_group_blackbox_test.go
+++ b/controller/work_item_type_group_blackbox_test.go
@@ -48,8 +48,8 @@ func (s *workItemTypeGroupSuite) TestList() {
 		// when
 		res, groups := test.ListWorkItemTypeGroupsOK(t, nil, s.svc, s.typeGroupsCtrl, sapcetemplateID)
 		// then
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.witg.golden.json"), groups)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.witg.golden.json"), groups)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.headers.golden.json"), res.Header())
 	})
 	s.T().Run("not found", func(t *testing.T) {
 		// given
@@ -59,8 +59,8 @@ func (s *workItemTypeGroupSuite) TestList() {
 		// then
 		ignoreMe := "IGNOREME"
 		jerrs.Errors[0].ID = &ignoreMe
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "not_found.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "not_found.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "not_found.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "not_found.headers.golden.json"), res.Header())
 	})
 }
 
@@ -71,8 +71,8 @@ func (s *workItemTypeGroupSuite) TestShow() {
 		// when
 		res, group := test.ShowWorkItemTypeGroupOK(t, nil, s.svc, s.typeGroupCtrl, typeGroupID)
 		// then
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.witg.golden.json"), group)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.witg.golden.json"), group)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 	})
 	s.T().Run("not found", func(t *testing.T) {
 		// given
@@ -82,7 +82,7 @@ func (s *workItemTypeGroupSuite) TestShow() {
 		// then
 		ignoreMe := "IGNOREME"
 		jerrs.Errors[0].ID = &ignoreMe
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.errors.golden.json"), jerrs)
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "show", "not_found.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.errors.golden.json"), jerrs)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_found.headers.golden.json"), res.Header())
 	})
 }

--- a/controller/workitemtype_blackbox_test.go
+++ b/controller/workitemtype_blackbox_test.go
@@ -243,22 +243,18 @@ func lookupWorkItemTypes(witCollection app.WorkItemTypeList, workItemTypes ...ap
 //-----------------------------------------------------------------------------
 
 func (s *workItemTypeSuite) TestCreate() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("ok", func(t *testing.T) {
 		res, animal := s.createWorkItemTypeAnimal()
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "animal.wit.golden.json"), animal)
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "animal.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "animal.wit.golden.json"), animal)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "animal.headers.golden.json"), res.Header())
 		res, person := s.createWorkItemTypePerson()
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "person.golden.json"), person)
-		compareWithGolden(t, filepath.Join(s.testDir, "create", "person.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "person.golden.json"), person)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "create", "person.headers.golden.json"), res.Header())
 	})
 }
 
 func (s *workItemTypeSuite) TestCreateByNotOwnerForbidden() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	s.T().Run("forbidden", func(t *testing.T) {
 		idn := &account.Identity{
@@ -326,7 +322,7 @@ func (s *workItemTypeSuite) TestValidate() {
 		gerr, ok := err.(*goa.ErrorResponse)
 		require.True(t, ok)
 		gerr.ID = "IGNORE_ME"
-		compareWithGolden(t, filepath.Join(s.testDir, "validate", "invalid_oversized_name.golden.json"), gerr)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "validate", "invalid_oversized_name.golden.json"), gerr)
 	})
 
 	s.T().Run("invalid - name starts with underscore", func(t *testing.T) {
@@ -340,13 +336,11 @@ func (s *workItemTypeSuite) TestValidate() {
 		gerr, ok := err.(*goa.ErrorResponse)
 		require.True(t, ok)
 		gerr.ID = "IGNORE_ME"
-		compareWithGolden(t, filepath.Join(s.testDir, "validate", "invalid_name_starts_with_underscore.golden.json"), gerr)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "validate", "invalid_name_starts_with_underscore.golden.json"), gerr)
 	})
 }
 
 func (s *workItemTypeSuite) TestShow() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
 
 	// given
 	_, wit := s.createWorkItemTypeAnimal()
@@ -359,8 +353,8 @@ func (s *workItemTypeSuite) TestShow() {
 		res, actual := test.ShowWorkitemtypeOK(t, nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, nil)
 		// then
 		require.NotNil(t, actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok.wit.golden.json"), actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.wit.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("ok - using expired IfModifiedSince header", func(t *testing.T) {
@@ -369,8 +363,8 @@ func (s *workItemTypeSuite) TestShow() {
 		res, actual := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, space.SystemSpace, *wit.Data.ID, &lastModified, nil)
 		// then
 		require.NotNil(t, actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.wit.golden.json"), actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.wit.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_lastmodified_header.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("ok - using IfNoneMatch header", func(t *testing.T) {
@@ -379,8 +373,8 @@ func (s *workItemTypeSuite) TestShow() {
 		res, actual := test.ShowWorkitemtypeOK(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, &ifNoneMatch)
 		// then
 		require.NotNil(t, actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.wit.golden.json"), actual)
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.wit.golden.json"), actual)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "ok_using_expired_etag_header.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("not modified - using IfModifiedSince header", func(t *testing.T) {
@@ -388,7 +382,7 @@ func (s *workItemTypeSuite) TestShow() {
 		lastModified := app.ToHTTPTime(time.Now().Add(119 * time.Second))
 		res := test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, &lastModified, nil)
 		// then
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "not_modified_using_if_modified_since_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_if_modified_since_header.headers.golden.json"), res.Header())
 	})
 
 	s.T().Run("not modified - using IfNoneMatch header", func(t *testing.T) {
@@ -396,7 +390,7 @@ func (s *workItemTypeSuite) TestShow() {
 		etag := generateWorkItemTypeTag(*wit)
 		res := test.ShowWorkitemtypeNotModified(s.T(), nil, nil, s.typeCtrl, *wit.Data.Relationships.Space.Data.ID, *wit.Data.ID, nil, &etag)
 		// then
-		compareWithGolden(t, filepath.Join(s.testDir, "show", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "show", "not_modified_using_ifnonematch_header.headers.golden.json"), res.Header())
 	})
 }
 

--- a/controller/workitemtypes_blackbox_test.go
+++ b/controller/workitemtypes_blackbox_test.go
@@ -213,9 +213,6 @@ func (s *workItemTypesSuite) TestValidate() {
 
 func (s *workItemTypesSuite) TestList() {
 	s.T().Run("ok", func(t *testing.T) {
-		resetFn := s.DisableGormCallbacks()
-		defer resetFn()
-
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemTypes(3, tf.SetWorkItemTypeNames("task", "bug", "feature")))
 		// when
@@ -230,7 +227,7 @@ func (s *workItemTypesSuite) TestList() {
 		}
 		require.Empty(t, toBeFound, "failed to find these work item types: %+v", toBeFound)
 
-		compareWithGoldenUUIDAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.payload.golden.json"), witCollection)
+		compareWithGoldenAgnostic(t, filepath.Join(s.testDir, "list", "ok.res.payload.golden.json"), witCollection)
 
 		require.NotNil(t, res.Header()[app.LastModified])
 		assert.Equal(t, app.ToHTTPTime(fxt.WorkItemTypes[0].UpdatedAt), res.Header()[app.LastModified][0])

--- a/design/space_template.go
+++ b/design/space_template.go
@@ -21,7 +21,7 @@ var spaceTemplate = a.Type("SpaceTemplate", func() {
 
 var spaceTemplateAttributes = a.Type("SpaceTemplateAttributes", func() {
 	a.Description(`JSONAPI store for all the "attributes" of a space template. See also see http://jsonapi.org/format/#document-resource-object-attributes`)
-	a.Attribute("name", d.String, "name of the space template", func() {
+	a.Attribute("name", d.String, mandatoryOnCreate("name of the space template"), func() {
 		a.Example("Issue Tracking")
 		a.MaxLength(62) // maximum space name length is 62 characters
 		a.MinLength(1)  // minimum space name length is 1 characters

--- a/gormtestsupport/db_test_suite.go
+++ b/gormtestsupport/db_test_suite.go
@@ -89,24 +89,3 @@ func (s *DBTestSuite) populateDBTestSuite(ctx context.Context) {
 func (s *DBTestSuite) TearDownSuite() {
 	s.DB.Close()
 }
-
-// DisableGormCallbacks will turn off gorm's automatic setting of `created_at`
-// and `updated_at` columns. Call this function and make sure to `defer` the
-// returned function.
-//
-//    resetFn := DisableGormCallbacks()
-//    defer resetFn()
-func (s *DBTestSuite) DisableGormCallbacks() func() {
-	gormCallbackName := "gorm:update_time_stamp"
-	// remember old callbacks
-	oldCreateCallback := s.DB.Callback().Create().Get(gormCallbackName)
-	oldUpdateCallback := s.DB.Callback().Update().Get(gormCallbackName)
-	// remove current callbacks
-	s.DB.Callback().Create().Remove(gormCallbackName)
-	s.DB.Callback().Update().Remove(gormCallbackName)
-	// return a function to restore old callbacks
-	return func() {
-		s.DB.Callback().Create().Register(gormCallbackName, oldCreateCallback)
-		s.DB.Callback().Update().Register(gormCallbackName, oldUpdateCallback)
-	}
-}

--- a/migration/sql-files/084-type-groups-and-child-types.sql
+++ b/migration/sql-files/084-type-groups-and-child-types.sql
@@ -40,3 +40,7 @@ CREATE TABLE work_item_child_types (
 );
 
 CREATE UNIQUE INDEX work_item_child_types_uidx ON work_item_child_types (parent_work_item_type_id, child_work_item_type_id) WHERE deleted_at IS NULL;
+
+-- Only allow one work item link type with the same name for the same space
+-- template in existence.
+CREATE UNIQUE INDEX work_item_link_types_name_idx ON work_item_link_types (name, space_template_id) WHERE deleted_at IS NULL;

--- a/workitem/link/link_repository_blackbox_test.go
+++ b/workitem/link/link_repository_blackbox_test.go
@@ -827,9 +827,6 @@ func (s *linkRepoBlackBoxTest) TestAncestorList() {
 }
 
 func (s *linkRepoBlackBoxTest) TestListChildLinks() {
-	resetFn := s.DisableGormCallbacks()
-	defer resetFn()
-
 	s.T().Run("ok", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB,

--- a/workitem/link/type.go
+++ b/workitem/link/type.go
@@ -99,8 +99,8 @@ func (t WorkItemLinkType) Equal(u convert.Equaler) bool {
 	return true
 }
 
-// CheckValidForCreation returns an error if the work item link type
-// cannot be used for the creation of a new work item link type.
+// CheckValidForCreation returns an error if the work item link type cannot be
+// used for the creation of a new work item link type.
 func (t *WorkItemLinkType) CheckValidForCreation() error {
 	if t.Name == "" {
 		return errors.NewBadParameterError("name", t.Name)

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -65,11 +65,11 @@ func (r *GormWorkItemLinkTypeRepository) Create(ctx context.Context, linkType *W
 	if db.Error != nil {
 		if gormsupport.IsUniqueViolation(db.Error, "work_item_link_types_name_idx") {
 			log.Error(ctx, map[string]interface{}{
-				"err":       db.Error,
-				"wilc_id":   linkType.LinkCategoryID,
-				"wilt_name": linkType.Name,
-			}, "unable to create work item link type because a link already exists with the same link_category_id and name")
-			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link type already exists with the same link_category_id: %s; name: %s ", linkType.LinkCategoryID, linkType.Name))
+				"err":               db.Error,
+				"space_template_id": linkType.SpaceTemplateID,
+				"wilt_name":         linkType.Name,
+			}, "unable to create work item link type because a link already exists with the same space_template_id and name")
+			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link type already exists with the same space_template_id: %s; name: %s ", linkType.SpaceTemplateID, linkType.Name))
 		}
 		log.Error(ctx, map[string]interface{}{
 			"wilt_id": linkType.ID.String(),
@@ -174,6 +174,15 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, modelToSave W
 	}
 	db = db.Save(&modelToSave)
 	if db.Error != nil {
+		if gormsupport.IsUniqueViolation(db.Error, "work_item_link_types_name_idx") {
+			log.Error(ctx, map[string]interface{}{
+				"err":               db.Error,
+				"space_template_id": existingModel.SpaceTemplateID,
+				"wilt_name":         existingModel.Name,
+				"wilt_id":           existingModel.ID,
+			}, "unable to save work item link type because a link already exists with the same space_template_id and name")
+			return nil, errors.NewDataConflictError(fmt.Sprintf("work item link type already exists with the same space_template_id: %s; name: %s ", existingModel.SpaceTemplateID, existingModel.Name))
+		}
 		log.Error(ctx, map[string]interface{}{
 			"wilt_id": existingModel.ID,
 			"wilt":    existingModel,

--- a/workitem/link/type_repository.go
+++ b/workitem/link/type_repository.go
@@ -22,7 +22,6 @@ type WorkItemLinkTypeRepository interface {
 	Create(ctx context.Context, linkType *WorkItemLinkType) (*WorkItemLinkType, error)
 	Load(ctx context.Context, ID uuid.UUID) (*WorkItemLinkType, error)
 	List(ctx context.Context, spaceTemplateID uuid.UUID) ([]WorkItemLinkType, error)
-	Delete(ctx context.Context, spaceTemplateID uuid.UUID, ID uuid.UUID) error
 	Save(ctx context.Context, linkCat WorkItemLinkType) (*WorkItemLinkType, error)
 }
 
@@ -129,7 +128,7 @@ func (r *GormWorkItemLinkTypeRepository) List(ctx context.Context, spaceTemplate
 
 	// We don't have any where clause or paging at the moment.
 	var modelLinkTypes []WorkItemLinkType
-	db := r.db.Where("space_template_id = ?", spaceTemplateID)
+	db := r.db.Where("space_template_id IN (?, ?)", spaceTemplateID, spacetemplate.SystemBaseTemplateID)
 	if err := db.Find(&modelLinkTypes).Error; err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"err":               err,
@@ -138,29 +137,6 @@ func (r *GormWorkItemLinkTypeRepository) List(ctx context.Context, spaceTemplate
 		return nil, errs.Wrapf(err, "failed to find link types")
 	}
 	return modelLinkTypes, nil
-}
-
-// Delete deletes the work item link type with the given id
-// returns NotFoundError or InternalError
-func (r *GormWorkItemLinkTypeRepository) Delete(ctx context.Context, spaceTemplateID uuid.UUID, ID uuid.UUID) error {
-	defer goa.MeasureSince([]string{"goa", "db", "workitemlinktype", "delete"}, time.Now())
-	var cat = WorkItemLinkType{
-		ID:              ID,
-		SpaceTemplateID: spaceTemplateID,
-	}
-	log.Info(ctx, map[string]interface{}{
-		"wilt_id":           ID,
-		"space_template_id": spaceTemplateID,
-	}, "Work item link type to delete %v", cat)
-
-	db := r.db.Delete(&cat)
-	if db.Error != nil {
-		return errors.NewInternalError(ctx, db.Error)
-	}
-	if db.RowsAffected == 0 {
-		return errors.NewNotFoundError("work item link type", ID.String())
-	}
-	return nil
 }
 
 // Save updates the given work item link type in storage. Version must be the same as the one int the stored version.
@@ -182,10 +158,20 @@ func (r *GormWorkItemLinkTypeRepository) Save(ctx context.Context, modelToSave W
 		}, "unable to find work item link type repository")
 		return nil, errors.NewInternalError(ctx, db.Error)
 	}
+	if err := modelToSave.CheckValidForCreation(); err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"wilt_id": modelToSave.ID.String(),
+			"err":     err,
+		}, "failed to validate link type to save")
+		return nil, errs.WithStack(err)
+	}
 	if existingModel.Version != modelToSave.Version {
 		return nil, errors.NewVersionConflictError("version conflict")
 	}
 	modelToSave.Version = modelToSave.Version + 1
+	if existingModel.SpaceTemplateID != modelToSave.SpaceTemplateID {
+		return nil, errors.NewForbiddenError("one must not change the space template reference in a work item link")
+	}
 	db = db.Save(&modelToSave)
 	if db.Error != nil {
 		log.Error(ctx, map[string]interface{}{

--- a/workitem/link/type_repository_blackbox_test.go
+++ b/workitem/link/type_repository_blackbox_test.go
@@ -1,0 +1,318 @@
+package link_test
+
+import (
+	"testing"
+
+	"github.com/fabric8-services/fabric8-wit/errors"
+	"github.com/fabric8-services/fabric8-wit/id"
+	"github.com/fabric8-services/fabric8-wit/ptr"
+	"github.com/fabric8-services/fabric8-wit/spacetemplate"
+	errs "github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/fabric8-services/fabric8-wit/gormtestsupport"
+	"github.com/fabric8-services/fabric8-wit/resource"
+	tf "github.com/fabric8-services/fabric8-wit/test/testfixture"
+	"github.com/fabric8-services/fabric8-wit/workitem/link"
+	_ "github.com/lib/pq" // need to import postgres driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type typeRepoBlackBoxTest struct {
+	gormtestsupport.DBTestSuite
+	typeRepo *link.GormWorkItemLinkTypeRepository
+}
+
+func TestRunTypeRepoBlackBoxTest(t *testing.T) {
+	resource.Require(t, resource.Database)
+	suite.Run(t, &typeRepoBlackBoxTest{DBTestSuite: gormtestsupport.NewDBTestSuite("../../config.yaml")})
+}
+
+func (s *typeRepoBlackBoxTest) SetupTest() {
+	s.DBTestSuite.SetupTest()
+	s.typeRepo = link.NewWorkItemLinkTypeRepository(s.DB)
+}
+
+func (s *typeRepoBlackBoxTest) TestList() {
+	s.T().Run("link types from base template", func(t *testing.T) {
+		// load all work item link types from base template
+		baseLinkTypes, err := s.typeRepo.List(s.Ctx, spacetemplate.SystemBaseTemplateID)
+		require.NoError(t, err)
+		require.NotEmpty(t, baseLinkTypes)
+		toBeFound := id.MapFromSlice(id.Slice{
+			link.SystemWorkItemLinkTypeBugBlockerID,
+			link.SystemWorkItemLinkPlannerItemRelatedID,
+			link.SystemWorkItemLinkTypeParentChildID,
+		})
+		for _, typ := range baseLinkTypes {
+			_, ok := toBeFound[typ.ID]
+			assert.True(t, ok, "found unexpected work item link type: %s", typ.Name)
+			delete(toBeFound, typ.ID)
+		}
+		require.Empty(t, toBeFound, "failed to find these work item link types: %s", toBeFound)
+	})
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB,
+			tf.SpaceTemplates(2),
+			tf.WorkItemLinkTypes(6, func(fxt *tf.TestFixture, idx int) error {
+				switch idx {
+				case 0, 1, 2, 3:
+					fxt.WorkItemLinkTypes[idx].SpaceTemplateID = fxt.SpaceTemplates[0].ID
+				case 4, 5:
+					fxt.WorkItemLinkTypes[idx].SpaceTemplateID = fxt.SpaceTemplates[1].ID
+				}
+				return nil
+			}),
+		)
+		t.Run("list by 1st space template", func(t *testing.T) {
+			// when
+			types, err := s.typeRepo.List(s.Ctx, fxt.SpaceTemplates[0].ID)
+			// then
+			require.NoError(t, err)
+			require.NotEmpty(t, types)
+			toBeFound := id.MapFromSlice(id.Slice{
+				fxt.WorkItemLinkTypes[0].ID,
+				fxt.WorkItemLinkTypes[1].ID,
+				fxt.WorkItemLinkTypes[2].ID,
+				fxt.WorkItemLinkTypes[3].ID,
+				// link types from base template
+				link.SystemWorkItemLinkTypeBugBlockerID,
+				link.SystemWorkItemLinkPlannerItemRelatedID,
+				link.SystemWorkItemLinkTypeParentChildID,
+			})
+			for _, typ := range types {
+				_, ok := toBeFound[typ.ID]
+				assert.True(t, ok, "found unexpected work item link type: %s", typ.Name)
+				delete(toBeFound, typ.ID)
+			}
+			require.Empty(t, toBeFound, "failed to find these work item link types: %s", toBeFound)
+		})
+		t.Run("list by 2nd space template", func(t *testing.T) {
+			// when
+			types, err := s.typeRepo.List(s.Ctx, fxt.SpaceTemplates[1].ID)
+			// then
+			require.NoError(t, err)
+			require.NotEmpty(t, types)
+			toBeFound := id.MapFromSlice(id.Slice{
+				fxt.WorkItemLinkTypes[4].ID,
+				fxt.WorkItemLinkTypes[5].ID,
+				// link types from base template
+				link.SystemWorkItemLinkTypeBugBlockerID,
+				link.SystemWorkItemLinkPlannerItemRelatedID,
+				link.SystemWorkItemLinkTypeParentChildID,
+			})
+			for _, typ := range types {
+				_, ok := toBeFound[typ.ID]
+				assert.True(t, ok, "found unexpected work item link type: %s", typ.Name)
+				delete(toBeFound, typ.ID)
+			}
+			require.Empty(t, toBeFound, "failed to find these work item link types: %s", toBeFound)
+		})
+	})
+
+	s.T().Run("not found", func(t *testing.T) {
+		// given
+		spaceTemplateID := uuid.NewV4()
+		// when
+		types, err := s.typeRepo.List(s.Ctx, spaceTemplateID)
+		// then
+		require.Error(t, err)
+		require.Empty(t, types)
+	})
+}
+
+func (s *typeRepoBlackBoxTest) TestLoad() {
+	resetFn := s.DisableGormCallbacks()
+	defer resetFn()
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
+		// when
+		typ, err := s.typeRepo.Load(s.Ctx, fxt.WorkItemLinkTypes[0].ID)
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, typ)
+		require.Equal(t, *fxt.WorkItemLinkTypes[0], *typ)
+		require.True(t, fxt.WorkItemLinkTypes[0].Equal(*typ))
+	})
+	s.T().Run("not found", func(t *testing.T) {
+		// given
+		linkTypeID := uuid.NewV4()
+		// when
+		typ, err := s.typeRepo.Load(s.Ctx, linkTypeID)
+		// then
+		require.Error(t, err)
+		require.Nil(t, typ)
+	})
+}
+
+func (s *typeRepoBlackBoxTest) TestCreate() {
+	resetFn := s.DisableGormCallbacks()
+	defer resetFn()
+
+	s.T().Run("ok", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.SpaceTemplates(1))
+		id := uuid.NewV4()
+		typ := link.WorkItemLinkType{
+			ID:              id,
+			Name:            id.String(),
+			Description:     ptr.String("description for WILT " + id.String()),
+			ReverseName:     "reverse name",
+			ForwardName:     "forward name",
+			Topology:        link.TopologyTree,
+			LinkCategoryID:  link.SystemWorkItemLinkCategoryUserID,
+			SpaceTemplateID: fxt.SpaceTemplates[0].ID,
+		}
+		// when
+		createdType, err := s.typeRepo.Create(s.Ctx, &typ)
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, createdType)
+		require.Equal(t, id, createdType.ID)
+		require.Equal(t, typ, *createdType)
+		require.True(t, typ.Equal(*createdType))
+		// check that loaded type is equal as well
+		loadedType, err := s.typeRepo.Load(s.Ctx, createdType.ID)
+		require.NoError(t, err)
+		require.Equal(t, typ, *loadedType)
+		require.True(t, typ.Equal(*loadedType))
+	})
+	s.T().Run("unknown topology (bad parameter error)", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.SpaceTemplates(1))
+		id := uuid.NewV4()
+		typ := link.WorkItemLinkType{
+			ID:              id,
+			Name:            id.String(),
+			Description:     ptr.String("description for WILT " + id.String()),
+			ReverseName:     "reverse name",
+			ForwardName:     "forward name",
+			Topology:        link.Topology("foobar"),
+			LinkCategoryID:  link.SystemWorkItemLinkCategoryUserID,
+			SpaceTemplateID: fxt.SpaceTemplates[0].ID,
+		}
+		// when
+		createdType, err := s.typeRepo.Create(s.Ctx, &typ)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.BadParameterError{}, errs.Cause(err))
+		require.Nil(t, createdType)
+	})
+	s.T().Run("empty name (bad parameter error)", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.SpaceTemplates(1))
+		id := uuid.NewV4()
+		typ := link.WorkItemLinkType{
+			ID:              id,
+			Name:            "",
+			Description:     ptr.String("description for WILT " + id.String()),
+			ReverseName:     "reverse name",
+			ForwardName:     "forward name",
+			Topology:        link.Topology("foobar"),
+			LinkCategoryID:  link.SystemWorkItemLinkCategoryUserID,
+			SpaceTemplateID: fxt.SpaceTemplates[0].ID,
+		}
+		// when
+		createdType, err := s.typeRepo.Create(s.Ctx, &typ)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.BadParameterError{}, errs.Cause(err))
+		require.Nil(t, createdType)
+	})
+	s.T().Run("unique name violation (internal error)", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
+		typ := *fxt.WorkItemLinkTypes[0]
+		typ.ID = uuid.NewV4()
+		// when
+		createdType, err := s.typeRepo.Create(s.Ctx, &typ)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.DataConflictError{}, errs.Cause(err))
+		require.Nil(t, createdType)
+	})
+}
+
+func (s *typeRepoBlackBoxTest) TestCheckExists() {
+	s.T().Run("existing", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
+		// when
+		err := s.typeRepo.CheckExists(s.Ctx, fxt.WorkItemLinkTypes[0].ID)
+		// then
+		require.NoError(t, err)
+	})
+	s.T().Run("nonexisting", func(t *testing.T) {
+		// given
+		linkTypeID := uuid.NewV4()
+		// when
+		err := s.typeRepo.CheckExists(s.Ctx, linkTypeID)
+		// then
+		require.Error(t, err)
+	})
+}
+
+func (s *typeRepoBlackBoxTest) TestSave() {
+	s.T().Run("version conflict", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
+		modelToSave := *fxt.WorkItemLinkTypes[0]
+		modelToSave.Version = modelToSave.Version + 10
+		// when
+		savedModel, err := s.typeRepo.Save(s.Ctx, modelToSave)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.VersionConflictError{}, errs.Cause(err))
+		require.Nil(t, savedModel)
+	})
+	s.T().Run("space template reference changed (forbidden)", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1), tf.SpaceTemplates(2))
+		modelToSave := *fxt.WorkItemLinkTypes[0]
+		modelToSave.SpaceTemplateID = fxt.SpaceTemplates[1].ID
+		// when
+		savedModel, err := s.typeRepo.Save(s.Ctx, modelToSave)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.ForbiddenError{}, errs.Cause(err))
+		require.Nil(t, savedModel)
+	})
+	s.T().Run("link type not found", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.SpaceTemplates(1))
+		id := uuid.NewV4()
+		modelToSave := link.WorkItemLinkType{
+			ID:              id,
+			Name:            id.String(),
+			Description:     ptr.String("description for WILT " + id.String()),
+			ReverseName:     "reverse name",
+			ForwardName:     "forward name",
+			Topology:        link.TopologyTree,
+			LinkCategoryID:  link.SystemWorkItemLinkCategoryUserID,
+			SpaceTemplateID: fxt.SpaceTemplates[0].ID,
+		}
+		// when
+		savedModel, err := s.typeRepo.Save(s.Ctx, modelToSave)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.NotFoundError{}, errs.Cause(err))
+		require.Nil(t, savedModel)
+	})
+	s.T().Run("unknown topology (internal error)", func(t *testing.T) {
+		// given
+		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
+		modelToSave := *fxt.WorkItemLinkTypes[0]
+		modelToSave.Topology = link.Topology("foobar")
+		// when
+		savedModel, err := s.typeRepo.Save(s.Ctx, modelToSave)
+		// then
+		require.Error(t, err)
+		require.IsType(t, errors.BadParameterError{}, errs.Cause(err))
+		require.Nil(t, savedModel)
+	})
+}

--- a/workitem/link/type_repository_blackbox_test.go
+++ b/workitem/link/type_repository_blackbox_test.go
@@ -224,7 +224,7 @@ func (s *typeRepoBlackBoxTest) TestCreate() {
 		require.IsType(t, errors.BadParameterError{}, errs.Cause(err))
 		require.Nil(t, createdType)
 	})
-	s.T().Run("unique name violation (internal error)", func(t *testing.T) {
+	s.T().Run("unique name violation (data conflict error)", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
 		typ := *fxt.WorkItemLinkTypes[0]
@@ -303,7 +303,7 @@ func (s *typeRepoBlackBoxTest) TestSave() {
 		require.IsType(t, errors.NotFoundError{}, errs.Cause(err))
 		require.Nil(t, savedModel)
 	})
-	s.T().Run("unknown topology (internal error)", func(t *testing.T) {
+	s.T().Run("unknown topology (bad parameter error)", func(t *testing.T) {
 		// given
 		fxt := tf.NewTestFixture(t, s.DB, tf.WorkItemLinkTypes(1))
 		modelToSave := *fxt.WorkItemLinkTypes[0]


### PR DESCRIPTION
* One can no longer delete a work item link type on repo-level.
* We now have the WILT repo fully covered with tests.
* Created missing `work_item_link_types_name_idx`.
* Listing link types on repo-level now includes the link types (parenting, relates to , blocks) from the base template.
